### PR TITLE
PROSTORIA-380 use flex instead of floating

### DIFF
--- a/bundle/Resources/public/admin/field_view.scss
+++ b/bundle/Resources/public/admin/field_view.scss
@@ -1,7 +1,14 @@
+.ibexa-embed-image-two-columns {
+    display: flex;
+}
+
 .ibexa-embed-type-image {
+    width: 100%;
+
     &.align-right,
     &.align-left {
         width: 50%;
+        float: none;
 
         .ibexa-field-preview__image-wrapper {
             flex-direction: column;

--- a/bundle/Resources/public/admin/field_view.scss
+++ b/bundle/Resources/public/admin/field_view.scss
@@ -8,7 +8,10 @@
     &.align-right,
     &.align-left {
         width: 50%;
-        float: none;
+
+        &:is(.ibexa-embed-image-two-columns .ibexa-embed-type-image) {
+            float: none;
+        }
 
         .ibexa-field-preview__image-wrapper {
             flex-direction: column;


### PR DESCRIPTION
ibexa renders the image as floating, which makes the text bend weird when using images in columns. removed the floating for columns and using flex instead