### PR TITLE
PROSTORIA-380 more general fixes for images, style centered differently

### DIFF
--- a/bundle/Resources/public/admin/field_view.scss
+++ b/bundle/Resources/public/admin/field_view.scss
@@ -1,5 +1,6 @@
-.ibexa-embed-image-two-columns {
+.ibexa-embed-image-two-columns:has(> *:not(:only-child)) {
     display: flex;
+    gap: 1rem;
 }
 
 .ibexa-embed-type-image {
@@ -9,16 +10,27 @@
     &.align-left {
         width: 50%;
 
-        &:is(.ibexa-embed-image-two-columns .ibexa-embed-type-image) {
+        &:not(:only-child) {
             float: none;
         }
+    }
 
-        .ibexa-field-preview__image-wrapper {
-            flex-direction: column;
-        }
+    &.align-center {
+        margin: 0;
 
-        .ibexa-field-preview__meta-wrapper {
-            margin-top: 8px;
+        .ibexa-field-preview__image {
+            display: flex;
+            justify-content: center;
+            margin: 0;
+            width: 100%;
+
+            img {
+                width: 80%;
+            }
+
+            .ibexa-field-preview__actions-wrapper {
+                right: 80px;
+            }
         }
     }
 }
@@ -26,13 +38,21 @@
 .ngremotemedia-field {
     .ibexa-field-preview__image-wrapper {
         display: flex;
-        flex-direction: row;
+        flex-direction: column;
+    }
+
+    .ibexa-field-preview__meta-wrapper {
+        margin-top: 8px;
     }
 
     .ibexa-field-preview__image {
         position: relative;
         max-width: unset;
-        width: fit-content;
+        width: 100%;
+
+        img {
+            width: 100%;
+        }
 
         video {
             max-width: 100%;

--- a/bundle/Resources/public/admin/field_view.scss
+++ b/bundle/Resources/public/admin/field_view.scss
@@ -29,7 +29,7 @@
             }
 
             .ibexa-field-preview__actions-wrapper {
-                right: 80px;
+                right: 11%;
             }
         }
     }


### PR DESCRIPTION
Changes for field view again

- made the flex display only if there are both children available - to enable properly viewing left aligned images where the text _should_ be to the side of it
    - wrapping of images within text will never be nice, its just how it is in text editors etc, look at Word and Google Docs for example, even LaTeX
- added a lot of 100% width for images to cover their space properly
- aligned images are 80% to make it clearer theyre specifically centered (as opposed to just placed in the body), the view button is offset some more/differently for them so its still over the image